### PR TITLE
Direct link to the racket docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # raco cross
 
-This the source for the Racket packages "raco-cross", "raco-cross-doc", and "raco-cross-lib".
+This the source for the [Racket packages](https://docs.racket-lang.org/raco-cross/index.html) "raco-cross", "raco-cross-doc", and "raco-cross-lib".
 
 ### Contributing
 


### PR DESCRIPTION
Adding a direct link to the racket docs, b/c I imagine I'm not the only one who wanted to go there from here.